### PR TITLE
Update metadata to support GNOME44

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
   "description": "Put a single task or goal in your menu bar",
   "name": "One Thing",
-  "shell-version": ["3.36", "3.38", "40", "41", "42", "43"],
+  "shell-version": ["3.36", "3.38", "40", "41", "42", "43", "44"],
   "url": "https://github.com/dantehemerson/one-thing",
   "uuid": "one-thing@github.com"
 }


### PR DESCRIPTION
The extensions works perfectly fine under GNOME 44, adding the supported version in the metadata allow user to install it on GNOME44