### PR TITLE
fix: Support Gnome Shell v47

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,8 @@
   "settings-schema": "org.gnome.shell.extensions.one-thing",
   "shell-version": [
     "45",
-		"46"
+		"46",
+    "47"
   ],
   "url": "https://github.com/dantehemerson/one-thing",
   "uuid": "one-thing@github.com",


### PR DESCRIPTION
Fix #23 