### PR TITLE
GNOME 48 Support, documentation changes and buildscript updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,29 @@
-.PHONY: all clean remake
+.PHONY: clean install schemas
 
-all: schemas/gschemas.compiled
+PREFIX ?= ${HOME}/.local
 
-schemas/gschemas.compiled: schemas/org.gnome.shell.extensions.one-thing.gschema.xml
-		glib-compile-schemas schemas/
+UUID   ?= one-thing@github.com
+BUNDLE = ${UUID}.zip
+
+ASSETS  = $(wildcard assets/*)
+SCHEMAS = $(wildcard schemas/*/*.gschema.xml)
+SOURCES = ${ASSETS} ${SCHEMAS} LICENSE entryMenu.js extension.js \
+	  metadata.json prefs.js prefs/hotkey.js \
+	  schemas/org.gnome.shell.extensions.one-thing.gschema.xml \
+	  stylesheet.css widget.js
+
+${BUNDLE}: ${SOURCES} schemas/gschemas.compiled
+	zip -q "$@" $^
+
+schemas/gschemas.compiled: ${SCHEMAS}
+	glib-compile-schemas schemas/
 
 clean:
-		rm -f schemas/gschemas.compiled
+	rm -f "${BUNDLE}"
+	rm -f schemas/gschemas.compiled
 
-remake: clean all
+install: ${BUNDLE}
+	rm -fr "${PREFIX}/share/gnome-shell/extensions/${BUNDLE}"
+	unzip  -q "${BUNDLE}" -d "${PREFIX}/share/gnome-shell/extensions/${BUNDLE}"
+
+schemas: schemas/gschemas.compile

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ clean:
 	rm -f schemas/gschemas.compiled
 
 install: ${BUNDLE}
-	rm -fr "${PREFIX}/share/gnome-shell/extensions/${BUNDLE}"
-	unzip  -q "${BUNDLE}" -d "${PREFIX}/share/gnome-shell/extensions/${BUNDLE}"
+	@touch "${PREFIX}/share/gnome-shell/extensions/${UUID}"
+	rm -r "${PREFIX}/share/gnome-shell/extensions/${UUID}"
+	unzip  -q "${BUNDLE}" -d "${PREFIX}/share/gnome-shell/extensions/${UUID}"
 
 schemas: schemas/gschemas.compile

--- a/README.md
+++ b/README.md
@@ -1,59 +1,97 @@
-# One-Thing Gnome Extension
+# One-Thing GNOME Extension
 
 > Put a single task or goal in your menu bar.
 
 One-Thing is a productivity tool that helps you stay focused on one task at a time.
 
-### Install
+## Installation
 
-You can install this extension from the gnome extension store: https://extensions.gnome.org/extension/5072/one-thing/
+You can install this extension from the GNOME Shell extensions store at <https://extensions.gnome.org/extension/5072/one-thing/>
 
-### Set the one-thing via command line
+## Scripting
 
+For scripting it is useful to set the one-thing *(displayed task)* non-interactively.
+This can be done via `dconf`.
+
+```sh
+$ dconf write /org/gnome/shell/extensions/one-thing/thing-value "'My todo'"
 ```
-dconf write /org/gnome/shell/extensions/one-thing/thing-value "'My todo'"
-```
 
-### Screenshots
+## Screenshots
 
 - **Task View**:
 
   <img src="./.github/screenshots/one-thing_2.png" alt="drawing" width="600"/>
 
-- **Edit Task**: Easly edit your task.
+- **Edit Task**: Easily edit your task
 
   <img src="./.github/screenshots/one-thing_1.png" alt="drawing" width="600"/>
 
-- **Preferences Window**: You can control the position of the task in the top bar
+- **Preferences Window**: You can control the position of the task in the top-bar
 
   <img src="./.github/screenshots/one-thing_3.png" alt="drawing" width="600"/>
 
+## Development
 
-### Development
+### Manual Installation
 
-**Manual installation (great for development)**
+There are two common patterns when developing a GNOME extension. Both are not harmful to
+the other installed extensions, so do what works for you!
 
-- Place this folder in **~/.local/share/gnome-shell/extensions**
-- Rename the folder to **one-thing<span>@</span>github.com** so the gnome
-  shell will find it
-- Build schemas with:
-  ```
-  npm run build-schemas
-  ```
-- **Debug extension:**
-  * X11: Reload gnome shell by pressing **Alt-F2** and then submit the
-    **r** command
-  * Wayland: To avoid restarting your computer, you can create nested session with:
-    ```
-    dbus-run-session -- gnome-shell --nested --wayland
-    ```
+#### Option 1: *great for rapid development*
 
-### Create Zip file to publish
+1. Clone this repository to `~/.local/share/gnome-shell/extensions`, so GNOME
+   Shell can find it:
+   ```sh
+   $ git clone git@github.com:one-thing-gnome/one-thing.git "${HOME}/.local/share/gnome-shell/extensions/one-thing@github.com"
+   ```
+2. Build the GSettings schema cache with:
+   ```sh
+   $ make schemas
+   ```
 
-Run:
+### Option 2: *great for manual installation*
 
+1. Optionally fork and clone this repository as usual
+2. Install the extension
+   1. For your user, overriding already installed versions
+      ```sh
+      $ make install
+      ```
+   2. For your user with an explicit development version co-installed
+      ```sh
+      $ PACKAGE=one-thing-devel@github.com.zip make install
+      ```
+   3. As system extension (not recommended)
+      ```sh
+      $ PREFIX=/usr/local make install
+      ```
+3. Once you're done, delete the local artefacts
+      ```sh
+      $ make clean
+      ```
+
+### Debugging the Extension
+
+Debugging the extension differs when you're running under X11 or Wayland. You can switch
+your session type by clicking on the cog in the login screen. When the environment
+variable `WAYLAND_DISPLAY` is set, you're on Wayland.
+
+#### GNOME Shell under X11
+
+Restart GNOME Shell by pressing **Alt-F2** and then submit the **r** command. Your apps
+will stay open and the shell will restart.
+
+#### GNOME Shell under Wayland
+
+Currently, Wayland can not be reloaded. To avoid logging out and closing all your apps,
+you can create nested GNOME session by running the following.
+
+```sh
+$ dbus-run-session -- gnome-shell --nested --wayland
 ```
-npm run pack
-```
 
-it will create `one-thing@github.com.zip` to upload to the gnome extension store.
+### Publishing the Extension
+
+Running `make` will create an extension bundle named `one-thing@github.com.zip` in the
+root of this folder. You can upload this to the GNOME extension store.

--- a/metadata.json
+++ b/metadata.json
@@ -4,10 +4,11 @@
   "settings-schema": "org.gnome.shell.extensions.one-thing",
   "shell-version": [
     "45",
-		"46",
-    "47"
+    "46",
+    "47",
+    "48"
   ],
   "url": "https://github.com/dantehemerson/one-thing",
   "uuid": "one-thing@github.com",
-  "version": 16
+  "version": 17
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,4 @@
 {
-	"scripts": {
-    "build-schemas": "make",
-		"pack": "rm -rf one-thing@github.com.zip && zip one-thing@github.com.zip LICENSE assets/* entryMenu.js extension.js metadata.json prefs.js prefs/* schemas/*.xml stylesheet.css widget.js"
-	},
   "devDependencies": {
     "eslint-plugin-jsdoc": "^46.8.2"
   }


### PR DESCRIPTION
Let me prefix this with, thank you for the extension! I literally use it only to display a cute flower in my panel haha

Apart from GNOME 48 support, I rewrote quite a bit of the README while trying to preserve your style of writing. The headings follow now the normal semantic flow, and I tried to make the contribution and build process a bit simpler.

Theoretically, installing the extension can also be done by calling `gnome-extension install`, but that would not allow for an installation in `/usr/local/share/gnome-shell/extensions`. In comparison, this approach allows for packaging the extension in a distro, without having to write custom scripts as a packager. In addition, I removed the recipe *remake*, because running make is essentially the same. All outputs override the previous ones, so they are fresh and freshly building can be forced via `make -B`

![image](https://github.com/user-attachments/assets/42d1c2b1-0789-4810-815f-1f96d026cc1d)

I played around with the options too, everything works